### PR TITLE
Allow multiple keys per buying group

### DIFF
--- a/config.yml.template
+++ b/config.yml.template
@@ -13,22 +13,28 @@ email:
 # This only works for PM/MYS/USA for now.
 groups:
   mysbuyinggroup:
-    # "key" is a unique string key that will appear in emails for a particular
+    # "keys" are unique strings that will appear in emails for a particular
     # group. For me, I use "man" plus the user ID since that shouldn't give
     # any false positives
-    key: man11414
+    keys:
+      - man11414
+      - Smith11414 # E.g. shipping to a fake name
     # username here is the website username (ditto password)
     username: gus.brodman@gmail.com
     password: 
   pointsmaker:
-    key: man17033
+    keys:
+      - man17033
     username: gus.brodman@gmail.com
     password:
   usa:
-    key: manGUBRO41
+    keys:
+      - manGUBRO41
     username: GUBRO41
     password:
   bfmr:
-    key: 51 s broadway
+    keys:
+      - 51 s broadway
   home:
-    key:
+    keys:
+      - 1234 Fake St

--- a/get_tracking_numbers.py
+++ b/get_tracking_numbers.py
@@ -27,9 +27,10 @@ TODO:
 def get_buying_group(raw_email):
     raw_email = raw_email.upper()
     for group in CONFIG['groups'].keys():
-        group_key = CONFIG['groups'][group]['key']
-        if group_key.upper() in raw_email:
-            return group
+        group_keys = CONFIG['groups'][group]['keys']
+        for group_key in group_keys:
+            if group_key.upper() in raw_email:
+                return group
     print(raw_email)
     raise Exception("Unknown buying group")
 


### PR DESCRIPTION
This is useful for when multiple accounts with other people's names are
being used, but the emails are still being forwarded into your main
email account.