### PR TITLE
Handle a single configured group key correctly

### DIFF
--- a/get_tracking_numbers.py
+++ b/get_tracking_numbers.py
@@ -35,4 +35,3 @@ if __name__ == "__main__":
     email_sender = EmailSender(EMAIL_CONFIG)
     email_sender.send_email(groups_dict)
     upload_numbers(email_sender, groups_dict)
-

--- a/tracking_retriever.py
+++ b/tracking_retriever.py
@@ -39,6 +39,8 @@ class TrackingRetriever:
         raw_email = raw_email.upper()
         for group in self.config['groups'].keys():
             group_keys = self.config['groups'][group]['keys']
+            if isinstance(group_keys, str):
+                group_keys = [group_keys]
             for group_key in group_keys:
                 if str(group_key).upper() in raw_email:
                     return group


### PR DESCRIPTION
Otherwise,  if you didn't define the key as a list, this ends up evaluating each single character
within a key for a match rather than that whole key itself,.