### PR TITLE
Allow for more generic search terms in email

### DIFF
--- a/lib/amazon_tracking_retriever.py
+++ b/lib/amazon_tracking_retriever.py
@@ -33,8 +33,9 @@ class AmazonTrackingRetriever(EmailTrackingRetriever):
       return match.group(1)
     return ''
 
-  def get_from_email_address(self):
-    return "shipment-tracking@amazon.com"
+  def get_subject_searches(self):
+    return [["Your AmazonSmile order", "has shipped"],
+            ["Your Amazon.com order", "has shipped"]]
 
   def get_merchant(self) -> str:
     return "Amazon"

--- a/lib/bestbuy_tracking_retriever.py
+++ b/lib/bestbuy_tracking_retriever.py
@@ -21,8 +21,8 @@ class BestBuyTrackingRetriever(EmailTrackingRetriever):
       return None
     return match.group(1)
 
-  def get_from_email_address(self):
-    return "BestBuyInfo@emailinfo.bestbuy.com"
+  def get_subject_searches(self):
+    return [["Your order #BBY01", "has shipped"]]
 
   def get_merchant(self) -> str:
     return "Best Buy"

--- a/lib/donations.py
+++ b/lib/donations.py
@@ -8,6 +8,7 @@ LAST_MONTH_FILE = OUTPUT_FOLDER + "/last_month.pickle"
 
 PAYPAL_URL = "https://www.paypal.me/gusbrodman"
 
+
 def should_open_page():
   # Open a donation page the first time the script is run every month
   this_month = datetime.date.today().strftime("%Y-%m")
@@ -23,6 +24,7 @@ def should_open_page():
   with open(LAST_MONTH_FILE, 'wb') as f:
     pickle.dump(this_month, f)
   return True
+
 
 if should_open_page():
   webbrowser.open(PAYPAL_URL)


### PR DESCRIPTION
Fixes #90 

IMAP requires exact string matching which is why we require multiple options -- searching for ["Your Amazon", "has shipped"] does not return "Your AmazonSmile order..." emails. 