### PR TITLE
Output the number of tracking #s per buying group in the email

### DIFF
--- a/lib/email_sender.py
+++ b/lib/email_sender.py
@@ -26,8 +26,7 @@ class EmailSender:
           tracking.tracking_number + " / " + ", ".join(tracking.order_ids) +
           " / " + tracking.to_email for tracking in trackings
       ]
-      content += group
-      content += '\n'
+      content += f"{group} ({len(numbers)}):\n"
       content += '\n'.join(numbers)
       content += '\n\n'
 


### PR DESCRIPTION
This is easy to calculate and a nice thing to know, especially for BGs
that still require manual tracking # input (e.g. BFMR).