### PR TITLE
Force BFMR tracking #s to upper case

### DIFF
--- a/lib/group_site_manager.py
+++ b/lib/group_site_manager.py
@@ -365,7 +365,7 @@ class GroupSiteManager:
       tds = tds[:-2]
 
       for i in range(len(tds) // 5):
-        tracking = tds[i * 5].getText()
+        tracking = tds[i * 5].getText().upper()
         total_text = tds[i * 5 + 4].getText()
         total = float(total_text.replace(',', '').replace('$', ''))
         print("%s: $%d" % (tracking, total))


### PR DESCRIPTION
I had a paid-out shipment that missed reconciliation because one of the tracking
numbers in the BFMR "Payment Sent" email was lower-case. This fixes this (rare)
failure case by simply forcing all tracking numbers to upper-case, which is the
canonical form.