### PR TITLE
Collectively track orders split up into separate orders by Amazon

### DIFF
--- a/lib/clusters.py
+++ b/lib/clusters.py
@@ -173,11 +173,15 @@ def find_by_shared_attr(cluster, all_clusters) -> Any:
     return None
 
   for candidate in all_clusters:
-    # This might be intersecting on null POs or email IDs
-    if candidate.group == cluster.group and (
-        candidate.purchase_orders.intersection(cluster.purchase_orders) or
-        candidate.email_ids.intersection(cluster.email_ids)):
-      return candidate
+    if candidate.group == cluster.group:
+      common_pos = candidate.purchase_orders.intersection(cluster.purchase_orders)
+      if common_pos:
+        print(f'Merged orders {cluster.orders} and {candidate.orders} by common POs {common_pos}')
+        return candidate
+      common_emails = candidate.email_ids.intersection(cluster.email_ids))
+      if common_emails:
+        print(f'Merged orders {cluster.orders} and {candidate.orders} by common email IDs {common_emails}')
+        return candidate
 
   return None
 

--- a/lib/clusters.py
+++ b/lib/clusters.py
@@ -11,7 +11,7 @@ CLUSTERS_FILE = OUTPUT_FOLDER + "/" + CLUSTERS_FILENAME
 class Cluster:
 
   def __init__(self, group) -> None:
-    self._initiate(set(), set(), group, 0, 0, '0', set(), 0.0)
+    self._initiate(set(), set(), group, 0, 0, '0', set(), set(), 0.0)
 
   def _initiate(self,
                 orders,
@@ -21,6 +21,7 @@ class Cluster:
                 tracked_cost,
                 last_ship_date='0',
                 purchase_orders=set(),
+                email_ids=set(),
                 adjustment=0.0,
                 to_email='',
                 notes='',
@@ -33,6 +34,7 @@ class Cluster:
     self.tracked_cost = tracked_cost
     self.last_ship_date = last_ship_date
     self.purchase_orders = purchase_orders
+    self.email_ids = email_ids
     self.adjustment = adjustment
     self.to_email = to_email
     self.notes = notes
@@ -43,10 +45,10 @@ class Cluster:
     self._initiate(**state)
 
   def __str__(self) -> str:
-    return "orders: %s, trackings: %s, group: %s, expected cost: %s, tracked cost: %s, last_ship_date: %s, purchase_orders: %s, adjustment: %s" % (
+    return "orders: %s, trackings: %s, group: %s, expected cost: %s, tracked cost: %s, last_ship_date: %s, purchase_orders: %s, email_ids: %s, adjustment: %s" % (
         str(self.orders), str(self.trackings), self.group,
         str(self.expected_cost), str(self.tracked_cost), self.last_ship_date,
-        str(self.purchase_orders), str(self.adjustment))
+        str(self.purchase_orders), str(self.email_ids), str(self.adjustment))
 
   def get_header(self) -> List[str]:
     return [
@@ -73,6 +75,7 @@ class Cluster:
     self.tracked_cost += other.tracked_cost
     self.last_ship_date = max(self.last_ship_date, other.last_ship_date)
     self.purchase_orders.update(other.purchase_orders)
+    self.email_ids.update(other.email_ids)
     self.adjustment += other.adjustment
     if self.notes and other.notes:
       self.notes += ", " + other.notes
@@ -144,7 +147,8 @@ def update_clusters(all_clusters, trackings) -> None:
     cluster.to_email = tracking.to_email
 
 
-def merge_by_purchase_orders(clusters) -> list:
+def merge_orders(clusters) -> list:
+  """ Merges together orders that share a common purchase order or email ID. """
   while True:
     prev_length = len(clusters)
     clusters = run_merge_iteration(clusters)
@@ -156,7 +160,7 @@ def merge_by_purchase_orders(clusters) -> list:
 def run_merge_iteration(clusters) -> list:
   result = []
   for cluster in clusters:
-    to_merge = find_by_purchase_orders(cluster, result)
+    to_merge = find_by_shared_attr(cluster, result)
     if to_merge:
       to_merge.merge_with(cluster)
     else:
@@ -164,13 +168,14 @@ def run_merge_iteration(clusters) -> list:
   return result
 
 
-def find_by_purchase_orders(cluster, all_clusters) -> Any:
-  if not cluster.purchase_orders:
+def find_by_shared_attr(cluster, all_clusters) -> Any:
+  if not cluster.purchase_orders and not cluster.email_ids:
     return None
 
   for candidate in all_clusters:
-    if candidate.group == cluster.group and candidate.purchase_orders.intersection(
-        cluster.purchase_orders):
+    if candidate.group == cluster.group and (
+        candidate.purchase_orders.intersection(cluster.purchase_orders) or
+        candidate.email_ids.intersection(cluster.email_ids)):
       return candidate
 
   return None
@@ -195,6 +200,7 @@ def from_row(header, row) -> Cluster:
       'Last Ship Date')] if 'Last Ship Date' in header else '0'
   pos_string = str(row[header.index('POs')]) if 'POs' in header else ''
   pos = set([s.strip() for s in pos_string.split(',')]) if pos_string else set()
+  email_ids = set() # Set this if we want email IDs in the Sheet
   group = row[header.index('Group')] if 'Group' in header else ''
   adj_string = row[header.index(
       "Manual Cost Adjustment")] if "Manual Cost Adjustment" in header else ''
@@ -205,6 +211,6 @@ def from_row(header, row) -> Cluster:
   notes = str(row[header.index('Notes')]) if 'Notes' in header else ''
   cluster = Cluster(group)
   cluster._initiate(orders, trackings, group, expected_cost, tracked_cost,
-                    last_ship_date, pos, adjustment, to_email, notes,
+                    last_ship_date, pos, email_ids, adjustment, to_email, notes,
                     manual_override, non_reimbursed_trackings)
   return cluster

--- a/lib/clusters.py
+++ b/lib/clusters.py
@@ -178,7 +178,7 @@ def find_by_shared_attr(cluster, all_clusters) -> Any:
       if common_pos:
         print(f'Merged orders {cluster.orders} and {candidate.orders} by common POs {common_pos}')
         return candidate
-      common_emails = candidate.email_ids.intersection(cluster.email_ids))
+      common_emails = candidate.email_ids.intersection(cluster.email_ids)
       if common_emails:
         print(f'Merged orders {cluster.orders} and {candidate.orders} by common email IDs {common_emails}')
         return candidate

--- a/lib/clusters.py
+++ b/lib/clusters.py
@@ -173,6 +173,7 @@ def find_by_shared_attr(cluster, all_clusters) -> Any:
     return None
 
   for candidate in all_clusters:
+    # This might be intersecting on null POs or email IDs
     if candidate.group == cluster.group and (
         candidate.purchase_orders.intersection(cluster.purchase_orders) or
         candidate.email_ids.intersection(cluster.email_ids)):

--- a/lib/order_info.py
+++ b/lib/order_info.py
@@ -24,7 +24,10 @@ class OrderInfo:
     self.cost = cost
 
   def __str__(self) -> str:
-    return f'email_id: {self.email_id}, cost: {self.cost}'
+    return f'{{email_id: {self.email_id}, cost: {self.cost}}}'
+
+  __repr__ = __str__
+
 
 class OrderInfoRetriever:
   """

--- a/lib/shipment_info.py
+++ b/lib/shipment_info.py
@@ -23,6 +23,8 @@ class OrderInfo:
     self.email_id = email_id
     self.cost = cost
 
+  def __str__(self) -> str:
+    return f'email_id: {self.email_id}, cost: {self.cost}'
 
 class ShipmentInfo:
   """
@@ -56,7 +58,9 @@ class ShipmentInfo:
       return pickle.load(stream)
 
   def get_order_info(self, order_id) -> OrderInfo:
-    if order_id not in self.shipments_dict or not self.shipments_dict[order_id]:
+    # Fetch the order from email if it's new or if we attempted to fetch it
+    # previously but weren't able to find a cost (i.e. cost is still 0).
+    if order_id not in self.shipments_dict or self.shipments_dict[order_id].cost == 0:
       from_email = self.load_order_total(order_id)
       if not from_email:
         from_email = {order_id: OrderInfo(None, 0.0)}

--- a/manual_input.py
+++ b/manual_input.py
@@ -8,7 +8,7 @@
 import datetime
 import lib.donations
 import yaml
-from lib.expected_costs import ExpectedCosts
+from lib.shipment_info import OrderInfo, ShipmentInfo
 from lib.tracking import Tracking
 from lib.tracking_output import TrackingOutput
 
@@ -48,7 +48,9 @@ def get_orders_to_costs():
     if not order_id:
       break
     price = float(get_required("Enter order cost, e.g. 206.76: "))
-    result[order_id] = price
+    # We don't (yet?) support manual entry of the email_id because it's a little
+    # bit of hassle to find through the Web UI.
+    result[order_id] = OrderInfo(None, price)
   return result
 
 
@@ -101,9 +103,9 @@ def run_add(config):
     output = TrackingOutput()
     output.save_trackings(config, [tracking])
     print("Wrote tracking")
-    ec = ExpectedCosts(config)
-    ec.costs_dict.update(orders_to_costs)
-    ec.flush()
+    shipment_info = ShipmentInfo(config)
+    shipment_info.shipments_dict.update(orders_to_costs)
+    shipment_info.flush()
     print("Wrote billed amounts")
     print("This will be picked up on next reconciliation run.")
   elif submit == 'n':

--- a/manual_input.py
+++ b/manual_input.py
@@ -8,7 +8,7 @@
 import datetime
 import lib.donations
 import yaml
-from lib.shipment_info import OrderInfo, ShipmentInfo
+from lib.order_info import OrderInfo, OrderInfoRetriever
 from lib.tracking import Tracking
 from lib.tracking_output import TrackingOutput
 
@@ -103,9 +103,9 @@ def run_add(config):
     output = TrackingOutput()
     output.save_trackings(config, [tracking])
     print("Wrote tracking")
-    shipment_info = ShipmentInfo(config)
-    shipment_info.shipments_dict.update(orders_to_costs)
-    shipment_info.flush()
+    order_info_retriever = OrderInfoRetriever(config)
+    order_info_retriever.orders_dict.update(orders_to_costs)
+    order_info_retriever.flush()
     print("Wrote billed amounts")
     print("This will be picked up on next reconciliation run.")
   elif submit == 'n':

--- a/reconcile.py
+++ b/reconcile.py
@@ -61,15 +61,18 @@ def fill_costs_by_po(all_clusters, po_to_cost, args):
 
 def fill_shipment_info(all_clusters, config):
   shipment_info = ShipmentInfo(config)
-  for cluster in tqdm(all_clusters, desc='Fetching order costs', unit='clus'):
-    cluster.expected_cost = 0.0
-    cluster.email_ids = set()
-    for order_id in cluster.orders:
-      order_info = shipment_info.get_order_info(order_id)
-      # Only add the email ID if it's present; don't add Nones!
-      if order_info.email_id:
-        cluster.email_ids.add(order_info.email_id)
-      cluster.expected_cost += order_info.cost
+  total_orders = sum([len(cluster.orders) for cluster in all_clusters])
+  with tqdm(desc='Fetching order costs', unit='order', total=total_orders) as pbar:
+    for cluster in all_clusters:
+      cluster.expected_cost = 0.0
+      cluster.email_ids = set()
+      for order_id in cluster.orders:
+        order_info = shipment_info.get_order_info(order_id)
+        # Only add the email ID if it's present; don't add Nones!
+        if order_info.email_id:
+          cluster.email_ids.add(order_info.email_id)
+        cluster.expected_cost += order_info.cost
+        pbar.update()
 
 
 def clusterify(config):

--- a/reconcile.py
+++ b/reconcile.py
@@ -3,9 +3,10 @@
 import argparse
 import lib.donations
 from lib import clusters
-import yaml
 import sys
-from lib.expected_costs import ExpectedCosts
+from tqdm import tqdm
+import yaml
+from lib.shipment_info import OrderInfo, ShipmentInfo
 from lib.group_site_manager import GroupSiteManager
 from lib.driver_creator import DriverCreator
 from lib.reconciliation_uploader import ReconciliationUploader
@@ -58,14 +59,14 @@ def fill_costs_by_po(all_clusters, po_to_cost, args):
           [po_to_cost.get(po, 0.0) for po in cluster.purchase_orders])
 
 
-def fill_expected_costs(all_clusters, config):
-  expected_costs = ExpectedCosts(config)
-  for cluster in all_clusters:
-    total_expected_cost = sum([
-        expected_costs.get_expected_cost(order_id)
-        for order_id in cluster.orders
-    ])
-    cluster.expected_cost = total_expected_cost
+def fill_shipment_info(all_clusters, config):
+  shipment_info = ShipmentInfo(config)
+  for cluster in tqdm(all_clusters, desc='Fetching order costs', unit='clus'):
+    cluster.expected_cost = 0.0
+    for order_id in cluster.orders:
+      order_info = shipment_info.get_order_info(order_id)
+      cluster.email_ids.add(order_info.email_id)
+      cluster.expected_cost += order_info.cost
 
 
 def clusterify(config):
@@ -78,7 +79,7 @@ def clusterify(config):
   clusters.update_clusters(all_clusters, trackings)
 
   print("Filling out expected costs and writing result to disk")
-  fill_expected_costs(all_clusters, config)
+  fill_shipment_info(all_clusters, config)
   clusters.write_clusters(config, all_clusters)
 
 
@@ -101,7 +102,7 @@ def main():
       config, driver_creator, args)
 
   fill_purchase_orders(all_clusters, tracking_to_po, args)
-  all_clusters = clusters.merge_by_purchase_orders(all_clusters)
+  all_clusters = clusters.merge_orders(all_clusters)
   fill_costs_by_po(all_clusters, po_to_cost, args)
 
   reconciliation_uploader.download_upload_clusters(all_clusters)

--- a/reconcile.py
+++ b/reconcile.py
@@ -65,7 +65,9 @@ def fill_shipment_info(all_clusters, config):
     cluster.expected_cost = 0.0
     for order_id in cluster.orders:
       order_info = shipment_info.get_order_info(order_id)
-      cluster.email_ids.add(order_info.email_id)
+      # Only add the email ID if it's present; don't add Nones!
+      if order_info.email_id:
+        cluster.email_ids.add(order_info.email_id)
       cluster.expected_cost += order_info.cost
 
 

--- a/reconcile.py
+++ b/reconcile.py
@@ -63,6 +63,7 @@ def fill_shipment_info(all_clusters, config):
   shipment_info = ShipmentInfo(config)
   for cluster in tqdm(all_clusters, desc='Fetching order costs', unit='clus'):
     cluster.expected_cost = 0.0
+    cluster.email_ids = set()
     for order_id in cluster.orders:
       order_info = shipment_info.get_order_info(order_id)
       # Only add the email ID if it's present; don't add Nones!

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ google-auth-oauthlib==0.4.0
 pytype==2019.9.6
 PyYAML==5.1.1
 selenium==3.141.0
+tqdm==4.40.0

--- a/set_cost.py
+++ b/set_cost.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 import yaml
-from lib.shipment_info import OrderInfo, ShipmentInfo
+from lib.order_info import OrderInfo, OrderInfoRetriever
 
 CONFIG_FILE = "config.yml"
 
@@ -10,16 +10,18 @@ def main():
   with open(CONFIG_FILE, 'r') as config_file_stream:
     config = yaml.safe_load(config_file_stream)
 
-  shipment_info = ShipmentInfo(config)
+  order_info_retriever = OrderInfoRetriever(config)
   while True:
     order = input("Enter order ID: ").strip()
     if not order:
       break
     cost = float(input("Enter cost: ").strip())
     # We don't (yet?) support manual entry of the email_id because it's a little
-    # bit of hassle to find through the Web UI.
-    shipment_info.shipments_dict[order] = OrderInfo(None, cost)
-    shipment_info.flush()
+    # bit of hassle to find through the Web UI. Reuse the email ID if there is one
+    existing_order_info = order_info_retriever.get_order_info(order)
+    email_id = existing_order_info.email_id if existing_order_info else None
+    order_info_retriever.orders_dict[order] = OrderInfo(email_id, cost)
+    order_info_retriever.flush()
 
 
 if __name__ == "__main__":

--- a/set_cost.py
+++ b/set_cost.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 import yaml
-from lib.expected_costs import ExpectedCosts
+from lib.shipment_info import OrderInfo, ShipmentInfo
 
 CONFIG_FILE = "config.yml"
 
@@ -10,14 +10,16 @@ def main():
   with open(CONFIG_FILE, 'r') as config_file_stream:
     config = yaml.safe_load(config_file_stream)
 
-  ec = ExpectedCosts(config)
+  shipment_info = ShipmentInfo(config)
   while True:
     order = input("Enter order ID: ").strip()
     if not order:
       break
     cost = float(input("Enter cost: ").strip())
-    ec.costs_dict[order] = cost
-    ec.flush()
+    # We don't (yet?) support manual entry of the email_id because it's a little
+    # bit of hassle to find through the Web UI.
+    shipment_info.shipments_dict[order] = OrderInfo(None, cost)
+    shipment_info.flush()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This has the effect of merging back together orders that Amazon has "split up"
into several orders, which generally is not what you want because buying groups
often reimburse different items in combos differently than how Amazon bills
them, and if the sub-orders aren't merged together, then many will appear to be
reimbursed below cost and others above cost.

This commit blows away the old expected_costs cache (because it did not contain
the email ID information which is necessary to be able to merge sub-orders
together). Thus, the first run after upgrading to this change is going to take
a long time because it will need to get all of the shipments info again from
scratch. Fortunately I added a nice progress bar for this too!

This fixes #114.