### PR TITLE
Allow manual_input.py to add order #s to an existing tracking #

### DIFF
--- a/get_tracking_numbers.py
+++ b/get_tracking_numbers.py
@@ -82,9 +82,9 @@ def main():
         raise
 
     print("Writing results to file")
-    tracking_output = TrackingOutput()
+    tracking_output = TrackingOutput(config)
     try:
-      tracking_output.save_trackings(config, trackings)
+      tracking_output.save_trackings(trackings)
     except:
       send_error_email(email_sender, "Error writing output file")
       raise

--- a/import_report.py
+++ b/import_report.py
@@ -93,13 +93,13 @@ def main():
       tracking.tracking_number != 'N/A' and tracking.tracking_number != ''
   ]
   all_trackings = dedupe_trackings(all_trackings)
-  tracking_output = TrackingOutput()
+  tracking_output = TrackingOutput(config)
   print("Number of trackings beforehand: %d" %
-        len(tracking_output.get_existing_trackings(config)))
+        len(tracking_output.get_existing_trackings()))
   print("Number from sheet: %d" % len(all_trackings))
-  tracking_output.save_trackings(config, all_trackings)
+  tracking_output.save_trackings(all_trackings)
   print("Number of trackings after: %d" %
-        len(tracking_output.get_existing_trackings(config)))
+        len(tracking_output.get_existing_trackings()))
 
 
 if __name__ == "__main__":

--- a/lib/tracking_output.py
+++ b/lib/tracking_output.py
@@ -1,10 +1,9 @@
 import collections
 import pickle
+from typing import List, Optional
 import os.path
 from lib.objects_to_drive import ObjectsToDrive
-from typing import Any, TypeVar
-
-_T0 = TypeVar('_T0')
+from lib.tracking import Tracking
 
 OUTPUT_FOLDER = "output"
 TRACKINGS_FILENAME = "trackings.pickle"
@@ -13,12 +12,26 @@ TRACKINGS_FILE = OUTPUT_FOLDER + "/" + TRACKINGS_FILENAME
 
 class TrackingOutput:
 
-  def save_trackings(self, config, trackings) -> None:
-    old_trackings = self.get_existing_trackings(config)
-    merged_trackings = self.merge_trackings(old_trackings, trackings)
-    self._write_merged(config, merged_trackings)
+  def __init__(self, config) -> None:
+    self.config = config
 
-  def _write_merged(self, config, merged_trackings) -> None:
+
+  def save_trackings(self, trackings, overwrite=False) -> None:
+    old_trackings = self.get_existing_trackings()
+    merged_trackings = self.merge_trackings(old_trackings, trackings, overwrite)
+    self._write_merged(merged_trackings)
+
+
+  def get_tracking(self, tracking_number) -> Optional[Tracking]:
+    """Returns the tracking object with the given tracking number if it exists."""
+    existing_trackings = self.get_existing_trackings()
+    for tracking in existing_trackings:
+      if tracking.tracking_number == tracking_number:
+        return tracking
+    return None
+
+
+  def _write_merged(self, merged_trackings) -> None:
     groups_dict = collections.defaultdict(list)
     for tracking in merged_trackings:
       groups_dict[tracking.group].append(tracking)
@@ -30,20 +43,21 @@ class TrackingOutput:
       pickle.dump(groups_dict, output)
 
     objects_to_drive = ObjectsToDrive()
-    objects_to_drive.save(config, TRACKINGS_FILENAME, TRACKINGS_FILE)
+    objects_to_drive.save(self.config, TRACKINGS_FILENAME, TRACKINGS_FILE)
 
   # Adds each Tracking object to the appropriate group
   # if there isn't already an entry for that tracking number
-  def merge_trackings(self, old_trackings: _T0, trackings) -> _T0:
-    old_tracking_numbers = set([ot.tracking_number for ot in old_trackings])
+  def merge_trackings(self, old_trackings: List[Tracking], trackings: List[Tracking], overwrite: bool) -> List[Tracking]:
+    new_tracking_dict = {t.tracking_number: t for t in old_trackings}
     for tracking in trackings:
-      if tracking.tracking_number not in old_tracking_numbers:
-        old_trackings.append(tracking)
-    return old_trackings
+      if not new_tracking_dict[tracking.tracking_number] or overwrite:
+        new_tracking_dict[tracking.tracking_number] = tracking
+    return list(new_tracking_dict.values())
 
-  def get_existing_trackings(self, config) -> Any:
+
+  def get_existing_trackings(self) -> List[Tracking]:
     objects_to_drive = ObjectsToDrive()
-    from_drive = objects_to_drive.load(config, TRACKINGS_FILENAME)
+    from_drive = objects_to_drive.load(self.config, TRACKINGS_FILENAME)
     if from_drive:
       return self._convert_to_list(from_drive)
 
@@ -57,6 +71,7 @@ class TrackingOutput:
       trackings_dict = pickle.load(tracking_file_stream)
     return self._convert_to_list(trackings_dict)
 
+
   def _convert_to_list(self, trackings_dict):
     result = []
     for trackings in trackings_dict.values():
@@ -64,6 +79,7 @@ class TrackingOutput:
     for tracking in result:
       tracking.tracking_number = tracking.tracking_number.upper()
     return result
+
 
   def clear(self) -> None:
     # self.write_merged([])

--- a/reconcile.py
+++ b/reconcile.py
@@ -77,9 +77,9 @@ def fill_order_info(all_clusters, config):
 
 
 def clusterify(config):
-  tracking_output = TrackingOutput()
+  tracking_output = TrackingOutput(config)
   print("Getting all tracking objects")
-  trackings = tracking_output.get_existing_trackings(config)
+  trackings = tracking_output.get_existing_trackings()
 
   print("Converting to Cluster objects")
   all_clusters = clusters.get_existing_clusters(config)


### PR DESCRIPTION
This is useful in the case of packages being shipped that contain multiple
orders that are combined together, because the "has shipped" email notification
does NOT contain all order #s for personal accounts. The only solution is to
painstakingly go through your list of all orders and manually enter the order #s
that are missing from the reconciliation sheet, along with the tracking #s that
they correspond to. Then run reconcile.py again and everything should be there.

This change also does some refactoring to the tracking_output module, in
particular making config an instance variable instead of requiring it on each
function call.

This partially addresses #81 