### PR TITLE
Add a get_tracking.py --seen scanning mode

### DIFF
--- a/generate_url.py
+++ b/generate_url.py
@@ -1,7 +1,6 @@
 import argparse
 from lib import create_url
 
-
 if __name__ == "__main__":
   parser = argparse.ArgumentParser(description='Create an add-to-cart URL')
   parser.add_argument("--no_smile", action="store_true")

--- a/get_tracking_numbers.py
+++ b/get_tracking_numbers.py
@@ -45,7 +45,8 @@ def main():
   email_sender = EmailSender(email_config)
 
   print("Retrieving Amazon tracking numbers from email...")
-  amazon_tracking_retriever = AmazonTrackingRetriever(config, args, driver_creator)
+  amazon_tracking_retriever = AmazonTrackingRetriever(config, args,
+                                                      driver_creator)
   try:
     trackings = amazon_tracking_retriever.get_trackings()
   except:
@@ -54,11 +55,13 @@ def main():
 
   action_taken = "" if args.seen else " and marked them as unread"
   if amazon_tracking_retriever.failed_email_ids:
-    print(f"Found {len(amazon_tracking_retriever.failed_email_ids)} Amazon emails "
-          f"without buying group labels{action_taken}. Continuing...")
+    print(
+        f"Found {len(amazon_tracking_retriever.failed_email_ids)} Amazon emails "
+        f"without buying group labels{action_taken}. Continuing...")
 
   print("Retrieving Best Buy tracking numbers from email...")
-  bestbuy_tracking_retriever = BestBuyTrackingRetriever(config, args, driver_creator)
+  bestbuy_tracking_retriever = BestBuyTrackingRetriever(config, args,
+                                                        driver_creator)
   try:
     trackings.update(bestbuy_tracking_retriever.get_trackings())
   except:
@@ -66,12 +69,14 @@ def main():
     raise
 
   if bestbuy_tracking_retriever.failed_email_ids:
-    print(f"Found {len(bestbuy_tracking_retriever.failed_email_ids)} Best Buy emails "
-          f"without buying group labels{action_taken}. Continuing...")
+    print(
+        f"Found {len(bestbuy_tracking_retriever.failed_email_ids)} Best Buy emails "
+        f"without buying group labels{action_taken}. Continuing...")
 
   try:
     tracking_output = TrackingOutput(config)
-    existing_tracking_nos = set([t.tracking_number for t in tracking_output.get_existing_trackings()])
+    existing_tracking_nos = set(
+        [t.tracking_number for t in tracking_output.get_existing_trackings()])
     new_tracking_nos = set(trackings.keys()).difference(existing_tracking_nos)
     print(f"Found {len(new_tracking_nos)} new tracking numbers "
           f"(out of {len(trackings)} total) from emails.")

--- a/get_tracking_numbers.py
+++ b/get_tracking_numbers.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 
+import argparse
 import lib.donations
 import sys
 import traceback
@@ -23,6 +24,10 @@ def send_error_email(email_sender, subject):
 
 
 def main():
+  parser = argparse.ArgumentParser(description='Get tracking #s script')
+  parser.add_argument("--seen", action="store_true")
+  args, _ = parser.parse_known_args()
+
   driver_creator = DriverCreator()
 
   with open(CONFIG_FILE, 'r') as config_file_stream:
@@ -31,7 +36,7 @@ def main():
   email_sender = EmailSender(email_config)
 
   print("Retrieving Amazon tracking numbers from email...")
-  amazon_tracking_retriever = AmazonTrackingRetriever(config, driver_creator)
+  amazon_tracking_retriever = AmazonTrackingRetriever(config, args, driver_creator)
   try:
     trackings = amazon_tracking_retriever.get_trackings()
   except:
@@ -44,7 +49,7 @@ def main():
         % len(amazon_tracking_retriever.failed_email_ids))
 
   print("Retrieving Best Buy tracking numbers from email...")
-  bestbuy_tracking_retriever = BestBuyTrackingRetriever(config, driver_creator)
+  bestbuy_tracking_retriever = BestBuyTrackingRetriever(config, args, driver_creator)
   try:
     bb_trackings = bestbuy_tracking_retriever.get_trackings()
     trackings.extend(bb_trackings)

--- a/lib/amazon_tracking_retriever.py
+++ b/lib/amazon_tracking_retriever.py
@@ -81,7 +81,9 @@ class AmazonTrackingRetriever(EmailTrackingRetriever):
     finally:
       driver.close()
 
-  @retry(stop=stop_after_attempt(7), wait=wait_exponential(multiplier=1, min=2, max=120))
+  @retry(
+      stop=stop_after_attempt(7),
+      wait=wait_exponential(multiplier=1, min=2, max=120))
   def load_url(self, url):
     driver = self.driver_creator.new()
     driver.get(url)

--- a/lib/amazon_tracking_retriever.py
+++ b/lib/amazon_tracking_retriever.py
@@ -2,6 +2,7 @@ import quopri
 import re
 import time
 from bs4 import BeautifulSoup
+from tenacity import retry, stop_after_attempt, wait_exponential
 from lib.email_tracking_retriever import EmailTrackingRetriever
 from lib.tracking import Tracking
 
@@ -80,8 +81,9 @@ class AmazonTrackingRetriever(EmailTrackingRetriever):
     finally:
       driver.close()
 
+  @retry(stop=stop_after_attempt(7), wait=wait_exponential(multiplier=1, min=2, max=120))
   def load_url(self, url):
     driver = self.driver_creator.new()
     driver.get(url)
-    time.sleep(3)  # wait for page load because the timeouts can be buggy
+    time.sleep(1)  # wait for page load because the timeouts can be buggy
     return driver

--- a/lib/email_sender.py
+++ b/lib/email_sender.py
@@ -30,7 +30,7 @@ class EmailSender:
       content += '\n'.join(numbers)
       content += '\n\n'
 
-    content += "These are tracking numbers we found based on unread emails. Some may have been found in the past."
+    content += "These are the new tracking numbers that we have found. See the Google Sheet for all tracking numbers."
     return content
 
   def send_email_content(self, subject, content, recipients=[]) -> None:

--- a/lib/email_tracking_retriever.py
+++ b/lib/email_tracking_retriever.py
@@ -2,6 +2,7 @@ import datetime
 import email
 import imaplib
 from abc import ABC, abstractmethod
+from tqdm import tqdm
 from lib.tracking import Tracking
 import lib.tracking
 from typing import Any, Callable, Optional, TypeVar
@@ -41,7 +42,7 @@ class EmailTrackingRetriever(ABC):
           "shipping emails in the dates we searched.")
     trackings = {}
     try:
-      for email_id in self.all_email_ids:
+      for email_id in tqdm(self.all_email_ids, desc="Fetching trackings", unit="email"):
         tracking = self.get_tracking(email_id)
         if tracking:
           trackings[tracking.tracking_number] = tracking
@@ -116,20 +117,17 @@ class EmailTrackingRetriever(ABC):
     order_ids = self.get_order_ids_from_email(raw_email)
     group = self.get_buying_group(raw_email)
     tracking_number = self.get_tracking_number_from_email(raw_email)
-    print("Tracking: %s, Order(s): %s, Group: %s" %
-          (tracking_number, ",".join(order_ids), group))
+    tqdm.write(f"Tracking: {tracking_number}, Order(s): {order_ids}, Group: {group}")
     if tracking_number == None:
       self.failed_email_ids.append(email_id)
-      print("Could not find tracking number from email with order(s) %s" %
-            order_ids)
+      tqdm.write(f"Could not find tracking number from email with order(s) {order_ids}")
       self.mark_as_unread(email_id)
       return None
 
     items = self.get_items_from_email(data)
     if group == None:
       self.failed_email_ids.append(email_id)
-      print("Could not find buying group for email with order(s) %s" %
-            order_ids)
+      tqdm.write(f"Could not find buying group for email with order(s) {order_ids}")
       self.mark_as_unread(email_id)
       return None
 

--- a/lib/email_tracking_retriever.py
+++ b/lib/email_tracking_retriever.py
@@ -41,9 +41,10 @@ class EmailTrackingRetriever(ABC):
     print(f"Found {len(self.all_email_ids)} {seen_adj} {self.get_merchant()} "
           "shipping emails in the dates we searched.")
     trackings = {}
+    mail = self.get_all_mail_folder()
     try:
       for email_id in tqdm(self.all_email_ids, desc="Fetching trackings", unit="email"):
-        tracking = self.get_tracking(email_id)
+        tracking = self.get_tracking(email_id, mail)
         if tracking:
           trackings[tracking.tracking_number] = tracking
     except:
@@ -103,9 +104,7 @@ class EmailTrackingRetriever(ABC):
     msg = email.message_from_string(str(data[0][1], 'utf-8'))
     return str(msg['To']).replace('<', '').replace('>', '')
 
-  def get_tracking(self, email_id) -> Tracking:
-    mail = self.get_all_mail_folder()
-
+  def get_tracking(self, email_id, mail) -> Tracking:
     result, data = mail.uid("FETCH", email_id, "(RFC822)")
     raw_email = str(data[0][1]).replace("=3D",
                                         "=").replace('=\\r\\n', '').replace(

--- a/lib/email_tracking_retriever.py
+++ b/lib/email_tracking_retriever.py
@@ -43,7 +43,8 @@ class EmailTrackingRetriever(ABC):
     trackings = {}
     mail = self.get_all_mail_folder()
     try:
-      for email_id in tqdm(self.all_email_ids, desc="Fetching trackings", unit="email"):
+      for email_id in tqdm(
+          self.all_email_ids, desc="Fetching trackings", unit="email"):
         tracking = self.get_tracking(email_id, mail)
         if tracking:
           trackings[tracking.tracking_number] = tracking
@@ -116,17 +117,21 @@ class EmailTrackingRetriever(ABC):
     order_ids = self.get_order_ids_from_email(raw_email)
     group = self.get_buying_group(raw_email)
     tracking_number = self.get_tracking_number_from_email(raw_email)
-    tqdm.write(f"Tracking: {tracking_number}, Order(s): {order_ids}, Group: {group}")
+    tqdm.write(
+        f"Tracking: {tracking_number}, Order(s): {order_ids}, Group: {group}")
     if tracking_number == None:
       self.failed_email_ids.append(email_id)
-      tqdm.write(f"Could not find tracking number from email with order(s) {order_ids}")
+      tqdm.write(
+          f"Could not find tracking number from email with order(s) {order_ids}"
+      )
       self.mark_as_unread(email_id)
       return None
 
     items = self.get_items_from_email(data)
     if group == None:
       self.failed_email_ids.append(email_id)
-      tqdm.write(f"Could not find buying group for email with order(s) {order_ids}")
+      tqdm.write(
+          f"Could not find buying group for email with order(s) {order_ids}")
       self.mark_as_unread(email_id)
       return None
 
@@ -150,8 +155,7 @@ class EmailTrackingRetriever(ABC):
     for search_terms in subject_searches:
       search_terms = ['(SUBJECT "%s")' % phrase for phrase in search_terms]
       status, response = mail.uid('SEARCH', None, seen_filter,
-                                  f'(SINCE "{date_to_search}")',
-                                  *search_terms)
+                                  f'(SINCE "{date_to_search}")', *search_terms)
       email_ids = response[0].decode('utf-8')
       result.update(email_ids.split())
 

--- a/lib/stock/item_price_retriever.py
+++ b/lib/stock/item_price_retriever.py
@@ -22,7 +22,8 @@ class ItemPriceRetriever:
       time.sleep(2)
       table = driver.find_elements_by_tag_name("table")[0]
       rows = table.find_elements_by_tag_name("tr")[1:]
-      price_tds = table.find_elements_by_xpath("//td[contains(@class, 'price') and contains(@class, 'item-row')]")
+      price_tds = table.find_elements_by_xpath(
+          "//td[contains(@class, 'price') and contains(@class, 'item-row')]")
       for i in range(len(rows)):
         if len(price_tds) <= i:
           break

--- a/lib/tracking_output.py
+++ b/lib/tracking_output.py
@@ -15,12 +15,10 @@ class TrackingOutput:
   def __init__(self, config) -> None:
     self.config = config
 
-
   def save_trackings(self, trackings, overwrite=False) -> None:
     old_trackings = self.get_existing_trackings()
     merged_trackings = self.merge_trackings(old_trackings, trackings, overwrite)
     self._write_merged(merged_trackings)
-
 
   def get_tracking(self, tracking_number) -> Optional[Tracking]:
     """Returns the tracking object with the given tracking number if it exists."""
@@ -29,7 +27,6 @@ class TrackingOutput:
       if tracking.tracking_number == tracking_number:
         return tracking
     return None
-
 
   def _write_merged(self, merged_trackings) -> None:
     groups_dict = collections.defaultdict(list)
@@ -47,13 +44,14 @@ class TrackingOutput:
 
   # Adds each Tracking object to the appropriate group
   # if there isn't already an entry for that tracking number
-  def merge_trackings(self, old_trackings: List[Tracking], trackings: List[Tracking], overwrite: bool) -> List[Tracking]:
+  def merge_trackings(self, old_trackings: List[Tracking],
+                      trackings: List[Tracking],
+                      overwrite: bool) -> List[Tracking]:
     new_tracking_dict = {t.tracking_number: t for t in old_trackings}
     for tracking in trackings:
       if tracking.tracking_number not in new_tracking_dict or overwrite:
         new_tracking_dict[tracking.tracking_number] = tracking
     return list(new_tracking_dict.values())
-
 
   def get_existing_trackings(self) -> List[Tracking]:
     objects_to_drive = ObjectsToDrive()
@@ -71,7 +69,6 @@ class TrackingOutput:
       trackings_dict = pickle.load(tracking_file_stream)
     return self._convert_to_list(trackings_dict)
 
-
   def _convert_to_list(self, trackings_dict):
     result = []
     for trackings in trackings_dict.values():
@@ -79,7 +76,6 @@ class TrackingOutput:
     for tracking in result:
       tracking.tracking_number = tracking.tracking_number.upper()
     return result
-
 
   def clear(self) -> None:
     # self.write_merged([])

--- a/manual_input.py
+++ b/manual_input.py
@@ -95,7 +95,7 @@ def run_add(config):
     order_ids_set = set(tracking.order_ids)
     order_ids_set.update(orders_to_costs.keys())
     tracking.order_ids = list(order_ids_set)
-    tracking.price = '' # Zero out price for reconcile to fix later.
+    tracking.price = ''  # Zero out price for reconcile to fix later.
   else:
     ship_date = get_optional_with_default(
         "Optional ship date, formatted YYYY-MM-DD [%s]: " % TODAY, TODAY)

--- a/notify_stock.py
+++ b/notify_stock.py
@@ -59,4 +59,5 @@ if __name__ == "__main__":
   if new_items and email_list:
     content = create_email_content(new_items, item_list, sheet_id)
     recipients = [email_obj.email_address for email_obj in email_list]
-    email_sender.send_email_content("🚨 Newly in-stock Amazon items 🚨", content, recipients)
+    email_sender.send_email_content("🚨 Newly in-stock Amazon items 🚨", content,
+                                    recipients)

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,5 @@ google-auth-oauthlib==0.4.0
 pytype==2019.9.6
 PyYAML==5.1.1
 selenium==3.141.0
+tenacity==5.1.4
 tqdm==4.40.0


### PR DESCRIPTION
This will go through all of the *seen* shipped emails in the lookback period
(which defaults to 45 days) instead of all of the unseen ones. This is a much
larger number of emails generally, and is useful for catching shipping
notifications and tracking #s that may have been missed on the first pass for
whatever reason, e.g. because an email was accidentally manually opened prior to
being ingested by get_tracking, or Amazon has changed the tracking # for the
order without sending a new notification (which happens on rare occasions).

So it's thus a good idea to run this new mode every so often, probably every
couple weeks or so, to ensure that no shipped orders have slipped through the
cracks and were never picked up. Yes, this takes a long time; run it over night.

Subsequent PRs will add smarter functionality to this mode, including an errored
tracking # accumulator to be output at the end, better retry functionality, and
some kind of progress indicator.

This partially implements #118.