### PR TITLE
Clear manual override status when clusters are merged

### DIFF
--- a/lib/clusters.py
+++ b/lib/clusters.py
@@ -81,7 +81,8 @@ class Cluster:
       self.notes += ", " + other.notes
     elif other.notes:
       self.notes = other.notes
-    self.manual_override = self.manual_override and other.manual_override
+    # Always clear manual overriding status on a cluster merge.
+    self.manual_override = False
     self.non_reimbursed_trackings.update(other.non_reimbursed_trackings)
 
 


### PR DESCRIPTION
I've seen issues where merged clusters have manual override set to true even
though they're now very clearly missing a lot of un-rebated goods. This seems
to happen most frequently when sub-orders are merged by email when a new
sub-order ships. In these cases, make sure that the row is no longer checked off
as manually overridden.

This hopefully addresses #131.