### PR TITLE
Add ability to disable a given set of addresses from reconciliation

### DIFF
--- a/config.yml.template
+++ b/config.yml.template
@@ -43,6 +43,10 @@ groups:
   home:
     keys:
       - 1234 Fake St
+    # Disable these shipments from being reconciled (i.e. because they aren't
+    # intended for buying groups). If you ship buying group packages to home,
+    # remove this line.
+    reconcile: False
 
 # Uncomment this if you wish to set the lookback that we use for email searching.
 # The default is 30 days in the past--if you change it to 2, it will only search

--- a/get_tracking_numbers.py
+++ b/get_tracking_numbers.py
@@ -95,12 +95,14 @@ def main():
       send_error_email(email_sender, "Error uploading tracking numbers")
       raise
 
+    reconcilable_trackings = [t for t in new_trackings if t.reconcile]
+
     # Also only add new trackings to the sheet
-    if new_trackings:
+    if reconcilable_trackings:
       print("Adding results to Google Sheets")
       tracking_uploader = TrackingUploader(config)
       try:
-        tracking_uploader.upload_trackings(new_trackings)
+        tracking_uploader.upload_trackings(reconcilable_trackings)
       except:
         send_error_email(email_sender, "Error uploading to Google Sheets")
         raise

--- a/lib/clusters.py
+++ b/lib/clusters.py
@@ -86,7 +86,13 @@ class Cluster:
       print(f"Newly merged cluster {self.orders} manual override unset.")
       self.manual_override = False
     self.non_reimbursed_trackings.update(other.non_reimbursed_trackings)
-    self.reconcile = self.reconcile or other.reconcile
+    if self.reconcile is None or other.reconcile is None:
+      # On the off-chance that un-initialized values exist somewhere, always
+      # default reconciling to true.
+      self.reconcile = True
+    else:
+      # Otherwise, reconcile if either cluster is set to reconcile.
+      self.reconcile = self.reconcile or other.reconcile
 
 
 def dedupe_clusters(clusters) -> list:

--- a/lib/clusters.py
+++ b/lib/clusters.py
@@ -86,6 +86,7 @@ class Cluster:
       print(f"Newly merged cluster {self.orders} manual override unset.")
       self.manual_override = False
     self.non_reimbursed_trackings.update(other.non_reimbursed_trackings)
+    self.reconcile = self.reconcile or other.reconcile
 
 
 def dedupe_clusters(clusters) -> list:

--- a/lib/clusters.py
+++ b/lib/clusters.py
@@ -86,13 +86,6 @@ class Cluster:
       print(f"Newly merged cluster {self.orders} manual override unset.")
       self.manual_override = False
     self.non_reimbursed_trackings.update(other.non_reimbursed_trackings)
-    if self.reconcile is None or other.reconcile is None:
-      # On the off-chance that un-initialized values exist somewhere, always
-      # default reconciling to true.
-      self.reconcile = True
-    else:
-      # Otherwise, reconcile if either cluster is set to reconcile.
-      self.reconcile = self.reconcile or other.reconcile
 
 
 def dedupe_clusters(clusters) -> list:

--- a/lib/email_tracking_retriever.py
+++ b/lib/email_tracking_retriever.py
@@ -5,7 +5,7 @@ from abc import ABC, abstractmethod
 from tqdm import tqdm
 from lib.tracking import Tracking
 import lib.tracking
-from typing import Any, Callable, Optional, TypeVar
+from typing import Any, Callable, Optional, Tuple, TypeVar
 
 _FuncT = TypeVar('_FuncT', bound=Callable)
 
@@ -56,16 +56,18 @@ class EmailTrackingRetriever(ABC):
       raise
     return trackings
 
-  def get_buying_group(self, raw_email) -> Any:
+  def get_buying_group(self, raw_email) -> Tuple[str, bool]:
     raw_email = raw_email.upper()
     for group in self.config['groups'].keys():
-      group_keys = self.config['groups'][group]['keys']
+      group_conf = self.config['groups'][group]
+      reconcile = bool(group_conf['reconcile']) if 'reconcile' in group_conf else True
+      group_keys = group_conf['keys']
       if isinstance(group_keys, str):
         group_keys = [group_keys]
       for group_key in group_keys:
         if str(group_key).upper() in raw_email:
-          return group
-    return None
+          return group, reconcile
+    return None, True
 
   @abstractmethod
   def get_order_ids_from_email(self, raw_email) -> Any:
@@ -115,7 +117,7 @@ class EmailTrackingRetriever(ABC):
     url = self.get_order_url_from_email(raw_email)
     price = self.get_price_from_email(raw_email)
     order_ids = self.get_order_ids_from_email(raw_email)
-    group = self.get_buying_group(raw_email)
+    (group, reconcile) = self.get_buying_group(raw_email)
     tracking_number = self.get_tracking_number_from_email(raw_email)
     tqdm.write(
         f"Tracking: {tracking_number}, Order(s): {order_ids}, Group: {group}")
@@ -137,7 +139,7 @@ class EmailTrackingRetriever(ABC):
 
     merchant = self.get_merchant()
     return Tracking(tracking_number, group, order_ids, price, to_email, url,
-                    date, 0.0, items, merchant)
+                    date, 0.0, items, merchant, reconcile)
 
   def get_all_mail_folder(self) -> imaplib.IMAP4_SSL:
     mail = imaplib.IMAP4_SSL(self.email_config['imapUrl'])

--- a/lib/email_tracking_retriever.py
+++ b/lib/email_tracking_retriever.py
@@ -117,7 +117,7 @@ class EmailTrackingRetriever(ABC):
     url = self.get_order_url_from_email(raw_email)
     price = self.get_price_from_email(raw_email)
     order_ids = self.get_order_ids_from_email(raw_email)
-    (group, reconcile) = self.get_buying_group(raw_email)
+    group, reconcile = self.get_buying_group(raw_email)
     tracking_number = self.get_tracking_number_from_email(raw_email)
     tqdm.write(
         f"Tracking: {tracking_number}, Order(s): {order_ids}, Group: {group}")

--- a/lib/tracking.py
+++ b/lib/tracking.py
@@ -14,7 +14,8 @@ class Tracking:
                ship_date='0',
                tracked_cost=0.0,
                items='',
-               merchant='') -> None:
+               merchant='',
+               reconcile: bool = True) -> None:
     self.tracking_number = tracking_number
     self.group = group
     self.order_ids = order_ids
@@ -25,14 +26,17 @@ class Tracking:
     self.tracked_cost = tracked_cost
     self.items = items
     self.merchant = merchant
+    self.reconcile = reconcile
 
   def __setstate__(self, state) -> None:
     self.__init__(**state)
 
   def __str__(self) -> str:
-    return "number: %s, group: %s, order(s): %s, price: %s, to_email: %s, url: %s, ship_date: %s, items: %s, merchant: %s" % (
-        self.tracking_number, self.group, self.order_ids, self.price,
-        self.to_email, self.url, self.ship_date, self.items, self.merchant)
+    return (f"number: {self.tracking_number}, group: {self.group}, "
+            f"order(s): {self.order_ids}, price: {self.price}, "
+            f"to_email: {self.to_email}, url: {self.url}, "
+            f"ship_date: {self.ship_date}, items: {self.items}, "
+            f"merchant: {self.merchant}, reconcile: {self.reconcile}")
 
   def to_row(self) -> list:
     hyperlink = self._create_hyperlink()
@@ -84,4 +88,4 @@ def from_row(header, row) -> Tracking:
   items = row[header.index("Items")] if 'Items' in header else ""
   merchant = row[header.index("Merchant")] if 'Merchant' in header else ""
   return Tracking(tracking, group, orders, price, to_email, url, ship_date,
-                  tracked_cost, items)
+                  tracked_cost, items, reconcile=True)

--- a/reconcile.py
+++ b/reconcile.py
@@ -86,10 +86,11 @@ def clusterify(config):
   tracking_output = TrackingOutput(config)
   print("Getting all tracking objects")
   trackings = tracking_output.get_existing_trackings()
+  reconcilable_trackings = [t for t in trackings if t.reconcile]
 
   print("Converting to Cluster objects")
   all_clusters = clusters.get_existing_clusters(config)
-  clusters.update_clusters(all_clusters, trackings)
+  clusters.update_clusters(all_clusters, reconcilable_trackings)
 
   print("Filling out order info and writing results to disk")
   fill_order_info(all_clusters, config)


### PR DESCRIPTION
This also adds a new 'reconcile' attribute to existing trackings that defaults
to True, and is set to False on new incoming trackings for groups with disable
reconciliation.  Reconciliation-disabled trackings are still included in
tracking number emails, and they are still saved in the local and remote pickle
files, but they are never turned into clusters and are never uploaded to Google
Sheets.

This fixes #127.