### PR TITLE
Limit importing of manual override status from Sheet

### DIFF
--- a/lib/clusters.py
+++ b/lib/clusters.py
@@ -206,10 +206,16 @@ def find_by_shared_attr(cluster, all_clusters) -> Any:
 
 
 def from_row(header, row) -> Cluster:
-  orders = set(str(
-      row[header.index('Orders')]).split(',')) if 'Orders' in header else set()
-  trackings = set(str(row[header.index('Trackings')]).split(
-      ',')) if 'Trackings' in header else set()
+  if 'Orders' in header:
+    orders = set([o.strip() for o in str(row[header.index('Orders')]).split(',')])
+  else:
+    orders = set()
+
+  if 'Trackings' in header:
+    trackings = set([t.strip() for t in str(row[header.index('Trackings')]).split(',')])
+  else:
+    trackings = set()
+
   expected_cost_str = row[header.index(
       'Amount Billed')] if 'Amount Billed' in header else ''
   expected_cost = float(expected_cost_str) if expected_cost_str else 0.0
@@ -219,7 +225,7 @@ def from_row(header, row) -> Cluster:
   non_reimbursed_str = str(row[header.index("Non-Reimbursed Trackings")]
                           ) if "Non-Reimbursed Trackings" in header else ""
   non_reimbursed_trackings = set(
-      non_reimbursed_str.split(',')) if non_reimbursed_str else set()
+      [t.strip() for t in non_reimbursed_str.split(',')]) if non_reimbursed_str else set()
   last_ship_date = row[header.index(
       'Last Ship Date')] if 'Last Ship Date' in header else '0'
   pos_string = str(row[header.index('POs')]) if 'POs' in header else ''

--- a/lib/reconciliation_uploader.py
+++ b/lib/reconciliation_uploader.py
@@ -276,14 +276,20 @@ class ReconciliationUploader:
           cluster, downloaded_clusters)
       cluster.adjustment = sum(
           [candidate.adjustment for candidate in candidate_downloads])
-      cluster.notes = ", ".join([
+      cluster.notes = "; ".join([
           candidate.notes
           for candidate in candidate_downloads
-          if candidate.notes
+          if candidate.notes.strip()
       ])
-      if candidate_downloads:
-        cluster.manual_override = all(
-            [candidate.manual_override for candidate in candidate_downloads])
+      # Import the manual override boolean from the sheet's checkbox ONLY if:
+      # (a) no clusters have been merged in since the last sheet export and
+      # (b) there haven't been any new order IDs or tracking #s added to the
+      #     cluster since the last export.
+      if len(candidate_downloads) == 1:
+        sheet_cluster = candidate_downloads[0]
+        if (sheet_cluster.trackings == cluster.trackings and
+            sheet_cluster.orders == cluster.orders):
+          cluster.manual_override = sheet_cluster.manual_override
 
   def find_candidate_downloads(self, cluster, downloaded_clusters) -> list:
     result = []


### PR DESCRIPTION
We only want to import the manual override status from the Google Sheet if the
cluster is still exactly the same (no merges, no added orders or trackings). If
the cluster is no longer the same then whatever the user set on the manual
override checkbox is out of date and shouldn't be imported.

This also makes the Notes merging behavior smarter by checking if strings are
blank, not just empty, so you won't get long strings of commas anymore. It also
switches over to semi-colons, which is better because commas can often be found
in the text of an individual note.

This fixes #131.