### PR TITLE
Add more logging to tracking numbers

### DIFF
--- a/get_tracking_numbers.py
+++ b/get_tracking_numbers.py
@@ -79,7 +79,7 @@ def main():
         else:
           raise e
 
-    print("Uploading tracking numbers...")
+    print("Uploading all tracking numbers...")
     group_site_manager = GroupSiteManager(config, driver_creator)
     try:
       group_site_manager.upload(trackings.values())

--- a/lib/group_site_manager.py
+++ b/lib/group_site_manager.py
@@ -403,7 +403,6 @@ class GroupSiteManager:
           raise Exception("Unknown group: " + group)
 
         print("Upload complete for %s." % group)
-        return None
       except Exception as e:
         last_ex = e
         print("Received exception when uploading: " + str(e))
@@ -431,7 +430,7 @@ class GroupSiteManager:
     time.sleep(3)
     return driver
 
-  def _upload_oaks(self, numbers):
+  def _upload_oaks(self, numbers) -> None:
     driver = self._login_oaks()
     try:
       driver.find_element_by_id('ContentPlaceHolder1_btnUpload').click()
@@ -444,7 +443,7 @@ class GroupSiteManager:
     finally:
       driver.quit()
 
-  def _upload_bfmr(self, numbers):
+  def _upload_bfmr(self, numbers) -> None:
     for batch in util.chunks(numbers, 100):
       self._upload_bfmr_batch(batch)
 
@@ -495,7 +494,7 @@ class GroupSiteManager:
     finally:
       driver.quit()
 
-  def _upload_yrcw(self, numbers):
+  def _upload_yrcw(self, numbers) -> None:
     driver = self._login_yrcw()
     try:
       self._load_page(driver, YRCW_URL + "dashboard")
@@ -509,7 +508,7 @@ class GroupSiteManager:
     finally:
       driver.quit()
 
-  def _upload_melul(self, numbers, group, username, password):
+  def _upload_melul(self, numbers, group, username, password) -> None:
     driver = self._login_melul(group, username, password)
     try:
       self._load_page(driver, MANAGEMENT_URL_FORMAT % group)

--- a/lib/group_site_manager.py
+++ b/lib/group_site_manager.py
@@ -305,6 +305,7 @@ class GroupSiteManager:
     headers = self._get_usa_login_headers()
     data = {"trackings": ",".join(numbers)}
     requests.post(url=USA_API_TRACKINGS_URL, headers=headers, data=data)
+    print("Upload complete for usa.")
 
   # Downloads the CSV export for the group in question and returns it as a list of rows as dicts
   def _get_melul_csv(self, group: str, username: str, password: str) -> List[Dict[str, str]]:
@@ -384,6 +385,7 @@ class GroupSiteManager:
 
   def _upload_to_group(self, numbers: List[str], group: str) -> None:
     last_ex = None
+    print("Uploading tracking numbers to %s..." % group)
     for attempt in range(MAX_UPLOAD_ATTEMPTS):
       try:
         if group in self.melul_portal_groups:
@@ -437,12 +439,14 @@ class GroupSiteManager:
       driver.execute_script(f"document.getElementsByTagName('textarea')[0].value = '{js_input}';")
       driver.find_element_by_id('ContentPlaceHolder1_btnGrabar').click()
       time.sleep(2)
+      print("Upload complete for oaks.")
     finally:
       driver.quit()
 
   def _upload_bfmr(self, numbers) -> None:
     for batch in util.chunks(numbers, 100):
       self._upload_bfmr_batch(batch)
+    print("Upload complete for bfmr.")
 
   def _upload_bfmr_batch(self, numbers) -> None:
     group_config = self.config['groups']['bfmr']
@@ -502,6 +506,7 @@ class GroupSiteManager:
       time.sleep(0.5)
       driver.find_element_by_xpath("//button[text() = 'Submit All']").click()
       time.sleep(5)
+      print("Upload complete for yrcw")
     finally:
       driver.quit()
 
@@ -527,6 +532,7 @@ class GroupSiteManager:
       # TODO: This needs to wait for the success dialog to be displayed and then print the number
       #       of new trackings from that to the command line.
       time.sleep(5)
+      print("Upload complete for %s." % group)
     finally:
       driver.quit()
 

--- a/lib/group_site_manager.py
+++ b/lib/group_site_manager.py
@@ -301,7 +301,7 @@ class GroupSiteManager:
       await asyncio.gather(*tasks)
       return tracking_tuples_to_prices, pos_to_prices
 
-  def _upload_usa(self, numbers):
+  def _upload_usa(self, numbers) -> None:
     headers = self._get_usa_login_headers()
     data = {"trackings": ",".join(numbers)}
     requests.post(url=USA_API_TRACKINGS_URL, headers=headers, data=data)


### PR DESCRIPTION
This seemed useful to me, hopefully useful to others. When uploads were happening to multiple sites, I wasn't aware which site it was currently uploading to. This adds more logging around that.