### PR TITLE
Update config to allow for TOTP secret

### DIFF
--- a/config.yml.template
+++ b/config.yml.template
@@ -10,6 +10,7 @@ amazon:
   # otherwise leave blank
   email: my_email@gmail.com
   password: my_password
+  totp: two_factor_secret_key
 
 # The group should correspond to a PM/MYS-like website name if one exists.
 # If you wish to automatically upload the tracking numbers, include the site

--- a/config.yml.template
+++ b/config.yml.template
@@ -10,7 +10,7 @@ amazon:
   # otherwise leave blank
   email: my_email@gmail.com
   password: my_password
-  totp: two_factor_secret_key
+  totp: twofactorsecretkey-removeallspaces
 
 # The group should correspond to a PM/MYS-like website name if one exists.
 # If you wish to automatically upload the tracking numbers, include the site


### PR DESCRIPTION
This allows for a user to define their account's 2FA Authenticator Secret Key, which can then be used to automatically generate their TOTP and enter it automatically during Amazon login.