### PR TITLE
fix Amazon changes

### DIFF
--- a/lib/amazon_tracking_retriever.py
+++ b/lib/amazon_tracking_retriever.py
@@ -200,7 +200,7 @@ class AmazonTrackingRetriever(EmailTrackingRetriever):
                                    driver: WebDriver) -> List[Tuple[str, Optional[str]]]:
     self.load_url(driver, amazon_url)
     try:
-      element = driver.find_element_by_xpath("//*[contains(text(), 'Tracking ID')]")
+      element = driver.find_element_by_xpath("//div[@class='pt-delivery-card-trackingId']")
       regex = r'Tracking ID: ([a-zA-Z0-9]+)'
       match = re.match(regex, element.text)
       if not match:


### PR DESCRIPTION
Amazon has made some changes where they are serving up different tracking page formats (some sort of A/B testing). Whilst the wildcard XPath text search worked on the 'old' tracking page, it was broken on the new page. The proposed change appears to work across both formats.