### PR TITLE
Update Amazon Subject Search

### DIFF
--- a/lib/amazon_tracking_retriever.py
+++ b/lib/amazon_tracking_retriever.py
@@ -103,7 +103,7 @@ class AmazonTrackingRetriever(EmailTrackingRetriever):
     return ''
 
   def get_subject_searches(self):
-    return [["Your AmazonSmile order", "has shipped"], ["Your Amazon.com order", "has shipped"],
+    return [["Your AmazonSmile order", "has shipped"], ["Your Amazon.com order", "has shipped"], ["Shipped", "this Amazon delivery"],
             ["Shipped: Now arriving early"]]
 
   def get_merchant(self) -> str:


### PR DESCRIPTION
As Amazon is now requiring OTP on delivery for some packages, it comes with a new title: "Shipped: A one-time password is required for this Amazon delivery".